### PR TITLE
Handling multiple imports in the same line when using aliases

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -52,11 +52,9 @@ def get_all_imports(start_path):
                         for item in s.groups():
                             if "," in item:
                                 for match in item.split(","):
-                                    imports.append(match.strip())
+                                    imports.append(get_import_name_without_alias(match))
                             else:
-                                to_append = item.partition(
-                                    ' as ')[0].partition('.')[0]
-                                imports.append(to_append.strip())
+                                imports.append(get_import_name_without_alias(item))
     third_party_packages = set(imports) - set(set(packages) & set(imports))
     logging.debug(
         'Found third-party packages: {0}'.format(third_party_packages))
@@ -128,6 +126,10 @@ def get_pkg_names_from_import_names(pkgs):
                     break
             result.append(toappend)
     return result
+
+
+def get_import_name_without_alias(import_name):
+    return import_name.partition(' as ')[0].partition('.')[0].strip()
 
 
 def init(args):

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -82,6 +82,12 @@ class TestPipreqs(unittest.TestCase):
             for item in self.modules2:
                 self.assertTrue(item.lower() in data)
 
+    def test_get_import_name_without_alias(self):
+        import_name_with_alias = "requests as R"
+        expected_import_name_without_alias = "requests"
+        import_name_without_aliases = pipreqs.get_import_name_without_alias(import_name_with_alias)
+        self.assertEqual(import_name_without_aliases, expected_import_name_without_alias)
+
     def tearDown(self):
         try:
             os.remove(self.requirements_path)


### PR DESCRIPTION
* Fix for #13.
* Added tests for the new method `get_import_name_without_alias`