### PR TITLE
Skip irreverent directory and change logging level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,13 @@ output/*/index.html
 # Sphinx
 docs/_build
 .idea/
+# Created by https://www.gitignore.io/api/vim
+
+### Vim ###
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -32,10 +32,18 @@ REGEXP = [
 def get_all_imports(path):
     imports = []
     candidates = []
+    ignore_dirs = [".git", "__pycache__", "env"]
 
     for root, dirs, files in os.walk(path):
+        dirs[:] = [d for d in dirs if d not in ignore_dirs]
+
+        # for d in ignore_dirs:
+            # if d in dirs:
+                # dirs.remove(d)
+
         candidates.append(os.path.basename(root))
         files = [fn for fn in files if os.path.splitext(fn)[1] == ".py"]
+
         candidates += [os.path.splitext(fn)[0] for fn in files]
         for file_name in files:
             with open(os.path.join(root, file_name), "r") as f:

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -166,8 +166,8 @@ def init(args):
             os.path.join(args['<path>'], "requirements.txt"))
 
     if not args["--savepath"] and not args["--force"] and os.path.exists(path):
-        logging.info("Requirements.txt already exists, "
-                     "use --force to overwrite it")
+        logging.warning("Requirements.txt already exists, "
+                        "use --force to overwrite it")
         return
     generate_requirements_file(path, imports)
     logging.info("Successfully saved requirements file in " + path)


### PR DESCRIPTION
- Skip .git, env, \__pycache\__ when running get_all_imports()  
  - In the previous version, pipreqs walks through `env` and generate unnecessary imports
- Change logging level to warning when encountering `Requirements.txt already exists`