### PR TITLE
Walk Abstract Syntax Tree to find imports

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -68,14 +68,14 @@ def get_all_imports(path, encoding=None):
                                 raw_imports.add(subnode.name)
                         elif isinstance(node, ast.ImportFrom):
                             raw_imports.add(node.module)
-                except Exception, e:
+                except Exception as exc:
                     if ignore_errors:
-                        traceback.print_exc(e)
+                        traceback.print_exc(exc)
                         logging.warn("Failed on file: %s" % os.path.join(root, file_name))
                         continue
                     else:
                         logging.error("Failed on file: %s" % os.path.join(root, file_name))
-                        raise e
+                        raise exc
 
 
 

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -23,7 +23,7 @@ import sys
 import re
 import logging
 import codecs
-
+import ast, traceback
 from docopt import docopt
 import requests
 from yarg import json2package
@@ -42,8 +42,6 @@ else:
     open_func = codecs.open
 
 
-import ast, traceback
-
 def get_all_imports(path, encoding=None):
     imports = set()
     raw_imports = set()
@@ -60,6 +58,9 @@ def get_all_imports(path, encoding=None):
         for file_name in files:
             with open_func(os.path.join(root, file_name), "r", encoding=encoding) as f:
                 contents = f.read()
+                #contents = re.sub(re.compile("'''.+?'''", re.DOTALL), '', f.read())
+                #contents = re.sub(re.compile('""".+?"""', re.DOTALL), "", contents)
+
                 try:
                     tree = ast.parse(contents)
                 except Exception, e:

--- a/tests/_data/test.py
+++ b/tests/_data/test.py
@@ -43,7 +43,7 @@ import sys
 import signal
 import bs4
 import nonexistendmodule
-import boto as b, import peewee as p,
+import boto as b, peewee as p
 # import django
 import flask.ext.somext  # # #
 from sqlalchemy import model
@@ -58,4 +58,4 @@ import models
 def main():
     pass
 
-import after_method_should_be_ignored
+import after_method_is_valid_even_if_not_pep8

--- a/tests/_invalid_data/invalid.py
+++ b/tests/_invalid_data/invalid.py
@@ -1,0 +1,1 @@
+import boto as b, import peewee as p,

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -46,7 +46,7 @@ class TestPipreqs(unittest.TestCase):
         """
         Test that invalid python files cannot be imported.
         """
-        self.assertRaises(SyntaxError, pipreqs.get_all_imports, self.project_invalid)    
+        self.assertRaises(SyntaxError, pipreqs.get_all_imports, self.project_invalid)
 
     def test_get_imports_info(self):
         """
@@ -150,12 +150,10 @@ class TestPipreqs(unittest.TestCase):
         """
         try:
             os.remove(self.requirements_path)
-            pass
         except OSError:
             pass
         try:
             os.remove(self.alt_requirement_path)
-            pass
         except OSError:
             pass
 

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -46,8 +46,7 @@ class TestPipreqs(unittest.TestCase):
         """
         Test that invalid python files cannot be imported.
         """
-        with self.assertRaises(SyntaxError) as exc:
-            imports = pipreqs.get_all_imports(self.project_invalid)
+        self.assertRaises(SyntaxError, pipreqs.get_all_imports, self.project_invalid)    
 
     def test_get_imports_info(self):
         """


### PR DESCRIPTION
Rationale: Using regex means that you can only find the imports that are at the top of the page without any spaces between them. There's likely other issues, but that was the one that bit me. 

Caveat: Old method would parse files with broken syntax. This one will not.