### PR TITLE
Make pipreqs not write diplicate lines to requirements.txt file

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -182,7 +182,8 @@ def get_pkg_names(pkgs):
                 if item[0] == pkg:
                     toappend = item[1]
                     break
-            result.append(toappend)
+            if toappend not in result:
+                result.append(toappend)
     return result
 
 

--- a/tests/_data_duplicated_deps/db.py
+++ b/tests/_data_duplicated_deps/db.py
@@ -1,0 +1,6 @@
+import pymongo
+from bson.objectid import ObjectId
+
+# 'bson' package is mapped to 'pymongo'.
+# But running pipreqs should not result in two duplicated
+# lines 'pymongo==x.x.x'.

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -26,6 +26,7 @@ class TestPipreqs(unittest.TestCase):
         self.project = os.path.join(os.path.dirname(__file__), "_data")
         self.project_invalid = os.path.join(os.path.dirname(__file__), "_invalid_data")
         self.project_with_ignore_directory = os.path.join(os.path.dirname(__file__), "_data_ignore")
+        self.project_with_duplicated_deps = os.path.join(os.path.dirname(__file__), "_data_duplicated_deps")
         self.requirements_path = os.path.join(self.project, "requirements.txt")
         self.alt_requirement_path = os.path.join(
             self.project, "requirements2.txt")
@@ -42,6 +43,12 @@ class TestPipreqs(unittest.TestCase):
         self.assertFalse("__future__" in imports)
         self.assertFalse("django" in imports)
         self.assertFalse("models" in imports)
+
+    def test_deduplicate_dependencies(self):
+        imports = pipreqs.get_all_imports(self.project_with_duplicated_deps)
+        pkgs = pipreqs.get_pkg_names(imports)
+        self.assertEqual(len(pkgs), 1)
+        self.assertIn("pymongo", pkgs)
 
     def test_invalid_python(self):
         """

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -48,7 +48,7 @@ class TestPipreqs(unittest.TestCase):
         imports = pipreqs.get_all_imports(self.project_with_duplicated_deps)
         pkgs = pipreqs.get_pkg_names(imports)
         self.assertEqual(len(pkgs), 1)
-        self.assertIn("pymongo", pkgs)
+        self.assertTrue("pymongo" in pkgs)
 
     def test_invalid_python(self):
         """


### PR DESCRIPTION
Test file:
```python
import pymongo
from bson.objectid import ObjectId
```

For this file `pipreqs` generates the following `requirements.txt`:
```
pymongo==3.2.1
pymongo==3.2.1
```

This pull-request fixes this unfortunate behaviour by patching `get_pkg_names` function.