### PR TITLE
Explicitly support Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 language: python
 
 python:
+  - "3.5"
   - "3.4"
   - "3.3"
   - "2.7"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,7 +99,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for PyPy. Check
+3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, 3.5, and for PyPy. Check
    https://travis-ci.org/bndr/pipreqs/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
     test_suite='tests',
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
All tests pass on Python 3.5, so declare official support for it.