### PR TITLE
Declare support for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 language: python
 
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
   - "2.7"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,9 +99,9 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, and 3.4, 3.5, and for PyPy. Check
-   https://travis-ci.org/bndr/pipreqs/pull_requests
-   and make sure that the tests pass for all supported Python versions.
+3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, and PyPy. Check
+   https://travis-ci.org/bndr/pipreqs/pull_requests and make sure that the
+   tests pass for all supported Python versions.
 
 Tips
 ----

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='tests',
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35
+envlist = py27, py34, py35, py36
 
 [testenv]
 setenv =


### PR DESCRIPTION
All tests pass under Python 3.6, so declare official support for it.
Closes #68.