### PR TITLE
fix(pipreqs/mapping): correct arrow mapping

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -263,7 +263,6 @@ armstrong:armstrong.hatband
 armstrong:armstrong.templates.standard
 armstrong:armstrong.utils.backends
 armstrong:armstrong.utils.celery
-arrow:arrow_fatisar
 arstecnica:arstecnica.raccoon.autobahn
 arstecnica:arstecnica.sqlalchemy.async
 article-downloader:article_downloader


### PR DESCRIPTION
https://pypi.org/project/arrow/ is https://github.com/crsmithdev/arrow/, the real arrow.
https://pypi.org/project/arrow-fatisar/ is https://github.com/fatisar/arrow, a completely random, outdated fork.