### PR TITLE
Run Travis-CI tests inside of tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,17 @@ python:
   - "2.7"
   - "pypy"
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+# Use tox to run tests on Travis-CI to keep one unified method of running tests in any environment
 install: 
-    - "pip install -r requirements.txt"
-    - "pip install coverage"
-    - "pip install coveralls"
+    - pip install coverage coveralls tox-travis
 
-# command to run tests, e.g. python setup.py test
-script: coverage run --source=pipreqs setup.py test
-after_success:
-    coveralls
+# Command to run tests, e.g. python setup.py test
+script: tox
+
+# Use a build stage instead of after_success to get a single coveralls report
+jobs:
+  include:
+    - stage: Coveralls
+      script:
+        - coverage run --source=pipreqs setup.py test
+        - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, pypy
 
 [testenv]
 setenv =


### PR DESCRIPTION
By using tox instead of the default Travis-CI Python environments, we
ensure that we have a single entrypoint to testing both locally and in
CI. This reduces redundant code and makes it clear when test
environments don't match up on different platforms.