### PR TITLE
bugfix: f.close() only required if open succeeded

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -309,9 +309,10 @@ def parse_requirements(file_):
         logging.error("Failed on file: {}".format(file_))
         raise
     else:
-        data = [x.strip() for x in f.readlines() if x != "\n"]
-    finally:
-        f.close()
+        try:
+            data = [x.strip() for x in f.readlines() if x != "\n"]
+        finally:
+            f.close()
 
     data = [x for x in data if x[0].isalpha()]
 
@@ -375,16 +376,17 @@ def clean(file_, imports):
         logging.error("Failed on file: {}".format(file_))
         raise
     else:
-        for i in f.readlines():
-            if re_remove.match(i) is None:
-                to_write.append(i)
-        f.seek(0)
-        f.truncate()
+        try:
+            for i in f.readlines():
+                if re_remove.match(i) is None:
+                    to_write.append(i)
+            f.seek(0)
+            f.truncate()
 
-        for i in to_write:
-            f.write(i)
-    finally:
-        f.close()
+            for i in to_write:
+                f.write(i)
+        finally:
+            f.close()
 
     logging.info("Successfully cleaned up requirements in " + file_)
 


### PR DESCRIPTION
when open fails, instead of raising the original error, the "f.close()" was erroring in the final clause.