### PR TITLE
Fix oauth and sort bugs

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -800,7 +800,7 @@ nester:abofly
 nester:bssm_pythonSig
 novaclient:python_novaclient
 oauth2_provider:alauda_django_oauth
-oauth2client:google_api_python_client
+oauth2client:oauth2client
 odf:odfpy
 ometa:Parsley
 openid:python_openid

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -267,7 +267,7 @@ def get_pkg_names(pkgs):
         # simply use the package name.
         result.add(data.get(pkg, pkg))
     # Return a sorted list for backward compatibility.
-    return sorted(result)
+    return sorted(result, key=lambda s: s.lower())
 
 
 def get_name_without_alias(name):

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -69,6 +69,12 @@ class TestPipreqs(unittest.TestCase):
                 item['name'].lower() in self.modules,
                 "Import item appears to be missing " + item['name'])
 
+    def test_get_pkg_names(self):
+        pkgs = ['jury', 'Japan', 'camel', 'Caroline']
+        actual_output = pipreqs.get_pkg_names(pkgs)
+        expected_output = ['camel', 'Caroline', 'Japan', 'jury']
+        self.assertEqual(actual_output, expected_output)
+
     def test_get_use_local_only(self):
         """
         Test without checking PyPI, check to see if names of local imports matches what we expect


### PR DESCRIPTION
* The mapping file should use `oauth2client:oauth2client` instead of mapping to `google_api_client`.
* Changes the sorting of `get_pkg_names` to be case-insenstive, so that it's consistent with output one would expected from pip freeze. 