### PR TITLE
Add Cryptodome:pycryptodomex

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -10,6 +10,7 @@ BioSQL:biopython
 BuildbotStatusShields:BuildbotEightStatusShields
 ComputedAttribute:ExtensionClass
 Crypto:pycryptodome
+Cryptodome:pycryptodomex
 FSM:pexpect
 FiftyOneDegrees:51degrees_mobile_detector_v3_wrapper
 GeoBaseMain:GeoBasesDev


### PR DESCRIPTION
Ref: https://github.com/bndr/pipreqs/issues/66#issuecomment-415642021  This is a wholly separate package from pycryptodome (which replaced pycrypto in #124 ). This uses the name `Cryptodome` in import statements, which differentiates it from pycrpytodome. This package works while pycryptodome causes problems, when building binaries of python programs in pyinstaller, thanks to having a completely different name. (See [replace Pycrypto in pyinstaller](https://github.com/pyinstaller/pyinstaller/issues/2365#issuecomment-384069038) )