### PR TITLE
Add patricia-trie mapping

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -822,6 +822,7 @@ past:future
 paste:PasteScript
 path:forked_path
 path:path.py
+patricia:patricia-trie
 paver:Paver
 peak:ProxyTypes
 picasso:anderson.picasso


### PR DESCRIPTION
For this package: https://pypi.org/project/patricia-trie/. Old, but I think it's the
only pure-python trie implementation on pypi.