### PR TITLE
Add setuptools to stdlib

### DIFF
--- a/pipreqs/stdlib
+++ b/pipreqs/stdlib
@@ -336,6 +336,7 @@ sched
 ScrolledText
 select
 sets
+setuptools
 sgmllib
 sha
 shelve

--- a/pipreqs/stdlib
+++ b/pipreqs/stdlib
@@ -306,6 +306,7 @@ pickle
 pickletools
 pipes
 PixMapWrapper
+pkg_resources
 pkgutil
 platform
 plistlib


### PR DESCRIPTION
Not technically in the stdlib but it doesn't really make sense for pipreqs to report setuptools as a dependency just because it's imported in `setup.py`.