### PR TITLE
#127: add apache-airflow to mapping

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -1,6 +1,7 @@
 AG_fft_tools:agpy
 ANSI:pexpect
 Adafruit:Adafruit_Libraries
+apache-airflow:airflow
 App:Zope2
 Asterisk:py_Asterisk
 BB_jekyll_hook:bitbucket_jekyll_hook


### PR DESCRIPTION
add `apache-airflow` instead of `airflow` to requirements.txt.

See https://pypi.org/project/airflow/