### PR TITLE
Added PipEnv ".venv" to directories ignored and log filename when UnicodeDecodeError exception is caught.

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -100,7 +100,7 @@ def get_all_imports(
     raw_imports = set()
     candidates = []
     ignore_errors = False
-    ignore_dirs = [".hg", ".svn", ".git", ".tox", "__pycache__", "env", "venv"]
+    ignore_dirs = [".hg", ".svn", ".git", ".tox", "__pycache__", "env", "venv", ".venv"]
 
     if extra_ignore_dirs:
         ignore_dirs_parsed = []
@@ -118,9 +118,9 @@ def get_all_imports(
         candidates += [os.path.splitext(fn)[0] for fn in files]
         for file_name in files:
             file_name = os.path.join(root, file_name)
-            with open_func(file_name, "r", encoding=encoding) as f:
-                contents = f.read()
             try:
+                with open_func(file_name, "r", encoding=encoding) as f:
+                    contents = f.read()
                 tree = ast.parse(contents)
                 for node in ast.walk(tree):
                     if isinstance(node, ast.Import):


### PR DESCRIPTION
Pipreqs was failing with UnicodeDecodeError without indicating the filename that caused the error. The root case was PipEnv's ".venv" folder was being processed.

This PR adds ".venv" to directories to ignore, and moves the code that reads the file to process inside the try/catch block in order to log the filename that caused the issue.

The file that caused the failure was:

`/Users/XXXXX/dev/XXXXX/.venv/lib/python3.7/site-packages/IPython/core/tests/nonascii.py`

and the terminal output was:

```
$ pipreqs --debug 
Traceback (most recent call last):
  File "/Users/XXXXX/dev/XXXXX/.venv/bin/pipreqs", line 10, in <module>
    sys.exit(main())
  File "/Users/XXXXX/dev/XXXXX/.venv/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 470, in main
    init(args)
  File "/Users/XXXXX/dev/XXXXX/.venv/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 409, in init
    follow_links=follow_links)
  File "/Users/XXXXX/dev/XXXXX/.venv/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 122, in get_all_imports
    contents = f.read()
  File "/Users/XXXXX/dev/XXXXX/.venv/bin/../lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb1 in position 81: invalid start bytedatetime64
```

Although pipreqs would have worked properly adding "--ignore .venv" flag, the user would not easily know where it was failing.

My environment is:
- MacOS 10.15.2
- Python 3.7.3
- pipreqs==0.4.10