### PR TITLE
Fixed#133

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -430,6 +430,8 @@ def init(args):
         imports = local + get_imports_info(difference,
                                            proxy=proxy,
                                            pypi_server=pypi_server)
+    # sort imports based on lowercase name of package, similar to `pip freeze`.
+    imports = sorted(imports, key=lambda x: x['name'].lower())
 
     path = (args["--savepath"] if args["--savepath"] else
             os.path.join(input_path, "requirements.txt"))

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -99,6 +99,9 @@ class TestPipreqs(unittest.TestCase):
             data = f.read().lower()
             for item in self.modules[:-3]:
                 self.assertTrue(item.lower() in data)
+        # It should be sorted based on names.
+        data = data.strip().split('\n')
+        self.assertEqual(data, sorted(data))
 
     def test_init_local_only(self):
         """


### PR DESCRIPTION
Sorted `imports` based on `lowercase` package's `name`, similar to `pip freeze`.