### PR TITLE
Fix Pypy Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
       env: TOX_ENV=py34
     - python: 2.7
       env: TOX_ENV=py27
-    - python: pypy
-      env: TOX_ENV=pypy
+    - python: pypy3
+      env: TOX_ENV=pypy3
     - python: 3.6
       env: TOX_ENV=flake8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,12 @@ matrix:
     - python: 3.6
       env: TOX_ENV=flake8
 
+# This should ensure that all tests use the same pip version
+before_install:
+  - python -m pip install --upgrade pip
+
 # Use tox to run tests on Travis-CI to keep one unified method of running tests in any environment
-install: 
+install:
   - pip install coverage coveralls tox
 
 # Command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,6 @@ matrix:
     - python: 3.6
       env: TOX_ENV=flake8
 
-# This should ensure that all tests use the same pip version
-before_install:
-  - python -m pip install --upgrade pip
-
 # Use tox to run tests on Travis-CI to keep one unified method of running tests in any environment
 install:
   - pip install coverage coveralls tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, flake8
+envlist = py27, py34, py35, py36, pypy3, flake8
 
 [testenv]
 setenv =


### PR DESCRIPTION
Closes #235
I believe the pypy build, for some reason, was using older versions of our dependencies during its build process which caused it to fail. By upgrading pypy to pypy3, travis started using python 3 instead of 2.7 and pip 20 instead of 19 (like all other successfull builds). Somehow this fixed our issues, but it is important to note that neither the python nor the pip versions where responsible for the issue as noted in #235. 
I still don't know what exactly caused this, maybe upgrading the version of wheels in requirements.txt could also solve the problem, but at this point this is all speculation.