### PR TITLE
Update stdlib with dataclasses

### DIFF
--- a/pipreqs/stdlib
+++ b/pipreqs/stdlib
@@ -133,6 +133,7 @@ curses
 curses.ascii
 curses.panel
 curses.textpad
+dataclasses
 datetime
 dbhash
 dbm


### PR DESCRIPTION
Part of the standard lib since 3.7: https://docs.python.org/3.7/library/dataclasses.html