### PR TITLE
Decaptalized file name in log msg

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -469,7 +469,7 @@ def init(args):
             and not args["--savepath"]
             and not args["--force"]
             and os.path.exists(path)):
-        logging.warning("Requirements.txt already exists, "
+        logging.warning("requirements.txt already exists, "
                         "use --force to overwrite it")
         return
 


### PR DESCRIPTION
When trying to generate requirements.txt and file is already existent, the user message produced asks for "Requirements.txt" instead of "requirements.txt". 
This may cause some trouble when used in case sensitive env, as well as in automated scripts.