### PR TITLE
Move docopt and yarg imports to local scope

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -42,10 +42,7 @@ import logging
 import codecs
 import ast
 import traceback
-from docopt import docopt
 import requests
-from yarg import json2package
-from yarg.exceptions import HTTPError
 
 from pipreqs import __version__
 
@@ -180,6 +177,10 @@ def output_requirements(imports):
 
 def get_imports_info(
         imports, pypi_server="https://pypi.python.org/pypi/", proxy=None):
+
+    from yarg import json2package
+    from yarg.exceptions import HTTPError
+
     result = []
 
     for item in imports:
@@ -462,6 +463,8 @@ def init(args):
 
 
 def main():  # pragma: no cover
+    from docopt import docopt
+
     args = docopt(__doc__, version=__version__)
     log_level = logging.DEBUG if args['--debug'] else logging.INFO
     logging.basicConfig(level=log_level, format='%(levelname)s: %(message)s')


### PR DESCRIPTION
I wonder, would you consider moving the imported libraries from global to local scope?

My motivation comes from pipenv which bundles pipreqs alongside with its dependencies (_yarg_ and _docopt_), but it really uses only two functions (`get_all_imports`, `get_pkg_names`) which don't require them.
When moved, pipenv could stop bundling _yarg_ and _docopt_.