### PR TITLE
Fix 227

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Session.vim
 *~
 
 /pipreqs/*.bak
+.vscode/settings.json
+.gitignore
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ Session.vim
 /pipreqs/*.bak
 .vscode/settings.json
 .gitignore
-.gitignore
+

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,3 @@ Session.vim
 *~
 
 /pipreqs/*.bak
-.vscode/settings.json
-.gitignore
-

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ Usage
                               environments parameter in your terminal:
                               $ export HTTP_PROXY="http://10.10.1.10:3128"
                               $ export HTTPS_PROXY="https://10.10.1.10:1080"
+        --trusted-host        Ignore SSL warnings, recommended using with
+                              enterprise proxy.
         --debug               Print debug information
         --ignore <dirs>...    Ignore extra directories
         --encoding <charset>  Use encoding parameter for file open

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -19,6 +19,7 @@ Options:
                           parameter in your terminal:
                           $ export HTTP_PROXY="http://10.10.1.10:3128"
                           $ export HTTPS_PROXY="https://10.10.1.10:1080"
+    --trusted-host        Ignore SSL warnings, recommended using with enterprise proxy.
     --debug               Print debug information.
     --ignore <dirs>...    Ignore extra directories, each separated by a comma.
     --no-follow-links     Do not follow symbolic links in the project

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -161,8 +161,8 @@ def get_all_imports(
     return list(packages - data)
 
 
-def filter_line(l):
-    return len(l) > 0 and l[0] != "#"
+def filter_line(line):
+    return len(line) > 0 and line[0] != "#"
 
 
 def generate_requirements_file(path, imports):

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -19,7 +19,8 @@ Options:
                           parameter in your terminal:
                           $ export HTTP_PROXY="http://10.10.1.10:3128"
                           $ export HTTPS_PROXY="https://10.10.1.10:1080"
-    --trusted-host        Ignore SSL warnings, recommended using with enterprise proxy.
+    --trusted-host        Ignore SSL warnings, recommended using with
+                          enterprise proxy.
     --debug               Print debug information.
     --ignore <dirs>...    Ignore extra directories, each separated by a comma.
     --no-follow-links     Do not follow symbolic links in the project
@@ -182,13 +183,15 @@ def output_requirements(imports):
 
 
 def get_imports_info(
-        imports, pypi_server="https://pypi.python.org/pypi/", proxy=None, verify_ssl=True):
+        imports, pypi_server="https://pypi.python.org/pypi/", proxy=None,
+        verify_ssl=True):
     result = []
 
     for item in imports:
         try:
             response = requests.get(
-                "{0}{1}/json".format(pypi_server, item), proxies=proxy, verify=verify_ssl)
+                "{0}{1}/json".format(pypi_server, item), proxies=proxy,
+                verify=verify_ssl)
             if response.status_code == 200:
                 if hasattr(response.content, 'decode'):
                     data = json2package(response.content.decode())


### PR DESCRIPTION
I have added a new feature "--trusted-host" which disables the SSL verification of the requests sent by requests.get function call.
```
        --trusted-host        Ignore SSL warnings, recommended using with
                              enterprise proxy.
```

Currently trying to fix pypy and flake8 build problems