### PR TITLE
File read error was not catched.

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -111,9 +111,9 @@ def get_all_imports(
         candidates += [os.path.splitext(fn)[0] for fn in files]
         for file_name in files:
             file_name = os.path.join(root, file_name)
-            with open(file_name, "r", encoding=encoding) as f:
-                contents = f.read()
             try:
+                with open(file_name, "r", encoding=encoding) as f:
+                    contents = f.read()
                 tree = ast.parse(contents)
                 for node in ast.walk(tree):
                     if isinstance(node, ast.Import):


### PR DESCRIPTION
On some file read errors, the file name is not printed. Like:
`Traceback (most recent call last):
  File "/home/bob/.local/bin/pipreqs", line 8, in <module>
    sys.exit(main())
  File "/home/bob/.local/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 488, in main
    init(args)
  File "/home/bob/.local/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 418, in init
    follow_links=follow_links)
  File "/home/bob/.local/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 115, in get_all_imports
    contents = f.read()
  File "/usr/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 65: invalid continuation byte
`

Including file read inside the Try gives out better message:
`ERROR: Failed on file: /home/bob/foofaa/foofaaservice.py
Traceback (most recent call last):
  File "/home/bob/.local/bin/pipreqs", line 8, in <module>
    sys.exit(main())
  File "/home/bob/.local/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 488, in main
    init(args)
  File "/home/bob/.local/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 418, in init
    follow_links=follow_links)
  File "/home/bob/.local/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 131, in get_all_imports
    raise exc
  File "/home/bob/.local/lib/python3.7/site-packages/pipreqs/pipreqs.py", line 116, in get_all_imports
    contents = f.read()
  File "/usr/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 65: invalid continuation byte`