### PR TITLE
Please allow using this project a library

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -44,7 +44,6 @@ import re
 import logging
 import ast
 import traceback
-from docopt import docopt
 import requests
 from yarg import json2package
 from yarg.exceptions import HTTPError
@@ -602,6 +601,11 @@ def init(args):
 
 
 def main():  # pragma: no cover
+    try:
+        from docopt import docopt
+    except (ImportError, ModuleNotFoundError):
+        sys.exit("Please install docopt to use the command line")
+
     args = docopt(__doc__, version=__version__)
     log_level = logging.DEBUG if args["--debug"] else logging.INFO
     logging.basicConfig(level=log_level, format="%(levelname)s: %(message)s")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 requires-python = ">=3.9, <3.14"
 dependencies = [
     "yarg>=0.1.9",
-    "docopt>=0.6.2",
     "nbconvert>=7.11.0",
     "ipython>=8.12.3",
 ]
@@ -39,6 +38,10 @@ dev = [
     "coverage>=7.3.2",
     "sphinx>=7.2.6;python_version>='3.9'",
 ]
+cli = [
+    "docopt>=0.6.2",
+]
+
 [tool.poetry.group.dev.dependencies]  # for legacy usage
 flake8 = "^6.1.0"
 tox = "^4.11.3"


### PR DESCRIPTION
This project is very useful also as a library. For example, pipenv uses it here:

https://github.com/pypa/pipenv/blob/4fa67914f7562db947e1b30875cf96a709e8f4f5/pipenv/core.py#L219

Because of the top level import of docopt, it must also pull docopt as a dependecy. It would be really nice if we
could remove this dependency. 

