### PR TITLE
Update pipreqs.py

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -217,7 +217,7 @@ def get_locally_installed_packages(encoding=None):
                                     version = package[1].replace(
                                         ".dist", "").replace(".egg", "")
 
-                                packages[i_item] = {
+                                packages[package[0].lower()] = {
                                     'version': version,
                                     'name': package[0]
                                 }


### PR DESCRIPTION
Hello, i came across the same error as described here and made a quick fix: 
https://github.com/bndr/pipreqs/issues/265

Seems to work in my case, tested it with python 3.6.16, and i don't see why it should conflict with other versions