### PR TITLE
Mapping Telegram to python-telegram-bot

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -1061,6 +1061,7 @@ tasksitter:cerebrod
 tastypie:django_tastypie
 teamcity:teamcity_messages
 telebot:pyTelegramBotAPI
+telegram:python-telegram-bot
 tempita:Tempita
 tenjin:Tenjin
 termstyle:python_termstyle


### PR DESCRIPTION
telegram is a hollow pypi package, so pipreqs will try to install that instead of python-telegram-bot, which have a module named telegram.