### PR TITLE
added apparent_encoding to the decoding of pypi's json response

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -180,7 +180,7 @@ def get_imports_info(
                 "{0}{1}/json".format(pypi_server, item), proxies=proxy)
             if response.status_code == 200:
                 if hasattr(response.content, 'decode'):
-                    data = json2package(response.content.decode())
+                    data = json2package(response.content.decode(response.apparent_encoding))
                 else:
                     data = json2package(response.content)
             elif response.status_code >= 300:


### PR DESCRIPTION
The json response from pypi is not guaranteed to be all of the expected default encoding. When characters in a pypi package information are not the default encoding, this line here will error out. By using `response.apparent_encoding`, the encoding type is taken from the request's response to allow for a proper decode.

There are a lot of repositories that cause issues like this, but here is an example:
https://pypi.org/project/imath/