### PR TITLE
CI: Add Python 3.10 and 3.11, update actions, run weekly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,25 @@
 name: Tests and Codecov
-on: pull_request
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
 jobs:
     run_tests:
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.7]
+                python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.9"]
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
 
@@ -30,7 +36,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Install dependencies
               run: |
@@ -44,7 +50,7 @@ jobs:
               run: coverage xml
 
             - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v2
+              uses: codecov/codecov-action@v3
               with:
                   files: coverage.xml
                   fail_ci_if_error: true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, pypy3, flake8
+envlist = py36, py37, py38, py39, py310, py311, pypy3, flake8
 
 [gh-actions]
 python =
@@ -7,7 +7,9 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    pypy-3.7: pypy3
+    3.10: py310
+    3.11: py311
+    pypy-3.9: pypy3
 
 [testenv]
 setenv =


### PR DESCRIPTION
A bit of CI maintenance:
- Add Python 3.10 and 3.11 runs, and update the PyPy run to PyPy 3.9
- Update the used actions to the latest versions
- Also run on pushes, when manually triggered (`workflow_dispatch`) and once a week (Monday at 06:00 UTC)

Also updates the `tox.ini` with Python 3.10 and 3.11 environments.