### PR TITLE
Include python-json-log-formatter project

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -1146,3 +1146,4 @@ z3c:z3c.traverser
 z3c:z3c.zcmlhook
 zmq:pyzmq
 zopyx:zopyx.textindexng3
+python_logger:python-json-log-formatter


### PR DESCRIPTION
Project: `python-json-log-formatter` : https://pypi.org/project/python-json-log-formatter/
Import in code: `from python_logger import PythonLogger`