### PR TITLE
Require Python 3.7 or higher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.7]
+                python-version: [3.7, 3.8, 3.9, pypy-3.7]
 
         steps:
             - name: Checkout repository

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,7 +99,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, and PyPy. Check
+3. The pull request should work for Python 3.7 to 3.11, and PyPy. Check
    https://travis-ci.org/bndr/pipreqs/pull_requests and make sure that the
    tests pass for all supported Python versions.
 

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,11 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     test_suite='tests',
     entry_points={
@@ -54,4 +55,5 @@ setup(
             'pipreqs=pipreqs.pipreqs:main',
         ],
     },
+    python_requires='>=3.7',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py36, py37, py38, py39, pypy3, flake8
+envlist = py37, py38, py39, pypy3, flake8
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
Require Python 3.7 by setting `python_requires` in setup.py. Also updates the CI, tests and docs.