### PR TITLE
Update mapping socketio to python-socketio

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -1032,7 +1032,7 @@ slack:slackclient
 slugify:unicode_slugify
 smarkets:smk_python_sdk
 snappy:ctypes_snappy
-socketio:gevent_socketio
+socketio:python-socketio
 socketserver:pies2overrides
 sockjs:sockjs_tornado
 socks:SocksiPy_branch


### PR DESCRIPTION
Originally mapped to gevent-socketio, which is outdated and hasn't been updated since 2016. Anyone importing socketio is much more likely to mean python-socketio now.