### PR TITLE
Add --extra option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Usage
                               $ export HTTPS_PROXY="https://10.10.1.10:1080"
         --debug               Print debug information
         --ignore <dirs>...    Ignore extra directories, each separated by a comma
+        --extra <packages>... Add extra packages, each separated by a comma
         --no-follow-links     Do not follow symbolic links in the project
         --encoding <charset>  Use encoding parameter for file open
         --savepath <file>     Save the list of requirements in the given file

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -20,6 +20,7 @@ Options:
                           $ export HTTPS_PROXY="https://10.10.1.10:1080"
     --debug               Print debug information
     --ignore <dirs>...    Ignore extra directories, each separated by a comma
+    --extra <modules>...  Add extra modules, each separated by a comma
     --no-follow-links     Do not follow symbolic links in the project
     --encoding <charset>  Use encoding parameter for file open
     --savepath <file>     Save the list of requirements in the given file
@@ -434,6 +435,7 @@ def dynamic_versioning(scheme, imports):
 def init(args):
     encoding = args.get('--encoding')
     extra_ignore_dirs = args.get('--ignore')
+    extra_pkgs = args.get('--extra')
     follow_links = not args.get('--no-follow-links')
     input_path = args['<path>']
     if input_path is None:
@@ -441,6 +443,9 @@ def init(args):
 
     if extra_ignore_dirs:
         extra_ignore_dirs = extra_ignore_dirs.split(',')
+
+    if extra_pkgs:
+        extra_pkgs = extra_pkgs.split(',')
 
     path = (args["--savepath"] if args["--savepath"] else
             os.path.join(input_path, "requirements.txt"))
@@ -457,6 +462,8 @@ def init(args):
                                  extra_ignore_dirs=extra_ignore_dirs,
                                  follow_links=follow_links)
     candidates = get_pkg_names(candidates)
+    if extra_pkgs is not None:
+        candidates = list(set(candidates) | set(extra_pkgs))
     logging.debug("Found imports: " + ", ".join(candidates))
     pypi_server = "https://pypi.python.org/pypi/"
     proxy = None

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -217,6 +217,25 @@ class TestPipreqs(unittest.TestCase):
             for item in ['click', 'getpass']:
                 self.assertFalse(item.lower() in data)
 
+    def test_extra_module(self):
+        """
+        Test --extra parameter
+        """
+        pipreqs.init(
+            {'<path>': self.project_with_ignore_directory, '--savepath': None,
+                      '--print': False, '--use-local': None, '--force': True,
+                      '--proxy': None, '--pypi-server': None,
+                      '--extra': 'example,example2',
+                      '--diff': None,
+                      '--clean': None,
+                      '--mode': None
+             }
+        )
+        with open(os.path.join(self.project_with_ignore_directory, "requirements.txt"), "r") as f:
+            data = f.read().lower()
+            for item in ['example,example2']:
+                self.assertFalse(item.lower() in data)
+
     def test_dynamic_version_no_pin_scheme(self):
         """
         Test --mode=no-pin


### PR DESCRIPTION
By using the --extra option, users can add custom packages to the `requirements.txt` file, like so:
`$ pipreqs --extra pipreqs,example`
This command generates the correct file, alphabetized and all, including pipreqs and example (in this case).

This adds pipreqs itself and example to the `requirements.txt` file, as my original intention was to add pipreqs to the `requirements.txt` file. (I know there are severely easier ways to do so, but I implemented it anyway.)

I added the `test_extra_module()` test, which it passed alongside all other tests; should be good to go!