### PR TITLE
Bump wheel from 0.23.0 to 0.38.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-wheel==0.23.0
+wheel==0.38.1
 Yarg==0.1.9
 docopt==0.6.2

--- a/tests/_data_ignore/requirements.txt
+++ b/tests/_data_ignore/requirements.txt
@@ -1,0 +1,12 @@
+asposestorage==1.0.2
+beautifulsoup4==4.12.2
+boto==2.49.0
+docopt==0.6.2
+Flask==3.0.0
+ipython==8.16.1
+nose==1.3.7
+peewee==3.16.3
+pyflakes==3.1.0
+Requests==2.31.0
+SQLAlchemy==2.0.21
+ujson==5.8.0


### PR DESCRIPTION
Cherry Picked from https://github.com/bndr/pipreqs/pull/342.

All tests are running with no failures.