### PR TITLE
Test badge

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,30 @@
+name: CodeCov
+on:
+    workflow_run:
+        workflows: [Tests]
+        types: [completed]
+
+jobs:
+    coverage_report:
+        runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install coverage docopt yarg requests
+
+            - name: Calculate coverage
+              run: coverage run --source=pipreqs -m unittest discover
+
+            - name: Create XML report
+              run: coverage xml
+
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v3
+              with:
+                  files: coverage.xml
+                  fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests and Codecov
+name: Tests
 on:
   push:
   pull_request:
@@ -28,27 +28,3 @@ jobs:
 
             - name: Test with tox
               run: tox
-
-    coverage_report:
-        needs: run_tests
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
-
-            - name: Install dependencies
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install coverage docopt yarg requests
-
-            - name: Calculate coverage
-              run: coverage run --source=pipreqs -m unittest discover
-
-            - name: Create XML report
-              run: coverage xml
-
-            - name: Upload coverage to Codecov
-              uses: codecov/codecov-action@v3
-              with:
-                  files: coverage.xml
-                  fail_ci_if_error: true

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,8 @@
 ``pipreqs`` - Generate requirements.txt file for any project based on imports
 =============================================================================
 
-.. image:: https://img.shields.io/travis/bndr/pipreqs.svg
-        :target: https://travis-ci.org/bndr/pipreqs
-
+.. image:: https://github.com/bndr/pipreqs/actions/workflows/tests.yml/badge.svg?branch=master
+        :target: https://github.com/bndr/pipreqs/actions/workflows/tests.yml
 
 .. image:: https://img.shields.io/pypi/v/pipreqs.svg
         :target: https://pypi.python.org/pypi/pipreqs


### PR DESCRIPTION
[update status badge from travis to github action](https://github.com/bndr/pipreqs/commit/e2c0f6483df4a447adc42079d66617adee35ed4c) and [Break tests and codecov workflow in 2](https://github.com/bndr/pipreqs/commit/eabd8b91ff044c708d25f4936288fc2a0798d63f).

The idea is to have the status badge report if the tests are passing,
without considering codecov since it frequently fails due to some
network hickup that makes the report upload to fail.

This also makes things a bit more compartimentalized.