### PR TITLE
Automate Versioning, Release, and PyPI Publishing

### DIFF
--- a/.git-hooks/post-commit
+++ b/.git-hooks/post-commit
@@ -1,0 +1,10 @@
+#! /bin/bash
+version=`git diff HEAD^..HEAD -- "$(git rev-parse --show-toplevel)"/pyproject.toml | grep -m 1 '^\+.*version' | sed -s 's/[^A-Z0-9\.\-]//g'`
+
+if [[ ! $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(\-[A-Z]+\.[0-9]+)?$ ]]; then
+    echo -e "Skip tag: invalid version '$version'"
+    exit 1
+fi
+
+git tag -a "v$version" -m "`git log -1 --format=%s`"
+echo "Created a new tag, v$version"

--- a/.github/workflows/release_and_publish.yml
+++ b/.github/workflows/release_and_publish.yml
@@ -1,0 +1,32 @@
+name: Create and publish a release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ncipollo/release-action@v1
+        with:
+          name: Release ${{ github.ref_name }}
+          makeLatest: true
+  
+  publish_to_pypi:
+    name: Publish to PyPI
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Build and publish to PyPI
+        uses: JRubics/poetry-publish@v1.17
+        with:
+          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          ignore_dev_requirements: "yes"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,14 +66,19 @@ Ready to contribute? Here's how to set up `pipreqs` for local development.
 3. Pipreqs is developed using Poetry. Refer to the `documentation <https://python-poetry.org/docs/>`_ to install Poetry in your local environment. Next, you should install pipreqs's dependencies::
 
     $ poetry install --with dev
+    $ poetry self add poetry-bumpversion
 
-4. Create a branch for local development::
+4. Configure `./git-hooks/` directory so that it becomes visible to git hooks (this hook depends on `bash`, `sed` and `grep` - tools usually included in any linux distribution)::
+
+    $ git config core.hooksPath .git-hooks
+
+5. Create a branch for local development::
 
     $ git checkout -b name-of-your-bugfix-or-feature
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
+6. When you're done making changes, check that your changes pass flake8 and the tests, including testing other Python versions with tox::
 
     $ poetry run flake8 pipreqs tests
     $ poetry run python -m unittest discover
@@ -81,13 +86,13 @@ Ready to contribute? Here's how to set up `pipreqs` for local development.
     
     To test all versions of python using tox you need to have them installed and for this two options are recommended: `pyenv` or `asdf`.
 
-6. Commit your changes and push your branch to GitHub::
+7. Commit your changes and push your branch to GitHub::
 
     $ git add .
     $ git commit -m "Your detailed description of your changes."
     $ git push origin name-of-your-bugfix-or-feature
 
-7. Submit a pull request through the GitHub website.
+8. Submit a pull request through the GitHub website.
 
 Pull Request Guidelines
 -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ tox = "^4.11.3"
 coverage = "^7.3.2"
 sphinx = { version = "^7.2.6", python = ">=3.9" }
 
+[tool.poetry_bumpversion.file."pipreqs/__init__.py"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
# Pull Request Description

This pull request introduces a Git hook and a GitHub actions workflow to automate versioning, release creation, and PyPI publishing. I have closed the previous PR, https://github.com/bndr/pipreqs/pull/411, leaving it for testing. If this PR passes, we will need to close the https://github.com/bndr/pipreqs/pull/408 PR as well. Here's a summary of the changes:

1. **GitHub Actions Workflow:**
   - A workflow is triggered when a new version tag (formatted as `vX.X.X`) is pushed.
   - It automates the creation of a GitHub release and the publishing of a Python package to PyPI.

2. **Git Hook:**
   - Added a pre-commit Git hook to extract the version from `pyproject.toml` and create a corresponding version tag.

3. **Poetry bumpversion plugin**
   - Add support for https://pypi.org/project/poetry-bumpversion/. This solves the issue https://github.com/bndr/pipreqs/issues/422 in a poetry-compatible way.

# Testing this PR

- [ ] Configure `./git-hooks/` directory so that it becomes visible to git hooks.
  - `git config core.hooksPath .git-hooks`.
- [ ] Install **poetry-bumpversion** plugin.
  - `poetry self add poetry-bumpversion`.
- [ ] Update package version with `poetry version <major|minor|...>` (this will change both `pyproject.toml` and `pipreqs/__init__.py`).
- [ ] Add and commit changes, including `pyproject.toml` and `pipreqs/__init__.py`.
  - This will trigger the post-commit hook.
- [ ] Push the commit and the newly created tag.
  - For pushing a specific tag, `git push <remote> <tag>`.
- [ ] Wait for the workflow termination.

# Additional Notes
- In the GitHub action secrets setting, make sure that `PYPI_TOKEN` exists.
- For testing purposes, **you should** configure the workflow to publish to the test PyPI repository. Just add the following lines after `with:` on line 30.
  ```
  repository_name: "test-pypi"
  repository_url: "https://test.pypi.org/legacy/"
  ```
  - It's needed to create an account there. You might also want to change the token secret for `TEST_PYPI_TOKEN` (make sure that you create it on Test PyPI and added it on GitHub Action secrets).
  - You can also delete github releases and tags. If any was created by testing this workflow, just delete them.
- A successefully execution of this workflow can be found at https://github.com/pipreqsxp/pipreqs/actions/runs/7064783492. The release can be found at https://test.pypi.org/project/pipreqs-build-test/.