### PR TITLE
Fix flake8 environment in tox.ini file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,12 @@ python =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/pipreqs
-commands = python -m unittest discover
+commands = 
+    python -m unittest discover
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 pipreqs tests
 
 [flake8]
 exclude =


### PR DESCRIPTION
The way we configured the `tox.ini` file makes flake8 not to be run. Tox only run python tests for the `flake8` environment.

With this PR, tox will run flake8 for the `pipreqs` and `tests` folders as desired.