### PR TITLE
update tests badge in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 ``pipreqs`` - Generate requirements.txt file for any project based on imports
 =============================================================================
 
-.. image:: https://img.shields.io/travis/bndr/pipreqs.svg
-        :target: https://travis-ci.org/bndr/pipreqs
+.. image:: https://github.com/bndr/pipreqs/actions/workflows/tests.yml/badge.svg
+        :target: https://github.com/bndr/pipreqs/actions/workflows/tests.yml
 
 
 .. image:: https://img.shields.io/pypi/v/pipreqs.svg


### PR DESCRIPTION
Seems Travis testing was dropped some time ago, but the badge still refers to it instead of newly/actually used GitHub actions. Compared to #415, it links to the already existing CI workflows without any other changes... :flamingo: 

![](https://github.com/bndr/pipreqs/actions/workflows/tests.yml/badge.svg)

cc: @bndr