### PR TITLE
Added debug message to describe decode failures discussed in issue 214

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -177,8 +177,11 @@ def get_file_extensions():
 
 def read_file_content(file_name: str, encoding="utf-8"):
     if file_ext_is_allowed(file_name, DEFAULT_EXTENSIONS):
-        with open(file_name, "r", encoding=encoding) as f:
-            contents = f.read()
+        try:
+                contents = f.read()
+        except Exception as e:
+            logging.debug("Encountered exception when attempting to decode: {0}".format(file_name))
+            raise e
     elif file_ext_is_allowed(file_name, [".ipynb"]) and scan_noteboooks:
         contents = ipynb_2_py(file_name, encoding=encoding)
     return contents


### PR DESCRIPTION
I added this exception handler to deal with #214 which, although closed, can still cause grief if the user is not able to ignore sub directories that contain the culprit file. This does not resolve the decode error; but it provides an additional debug statement that names the file causing the error.