### PR TITLE
Add mapping `jose` -> `python-jose`

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -720,6 +720,7 @@ jaraco:jaraco.util
 jinja2:Jinja2
 jiracli:jira_cli
 johnny:johnny_cache
+jose:python_jose
 jpgrid:python_geohash
 jpiarea:python_geohash
 jpype:JPype1


### PR DESCRIPTION
`jose` is a Python 2 package. `python-jose` is its Python 3 successor.