### PR TITLE
Avoid test/tests folder to ignore the file encoding issue, beasuse so…

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -110,6 +110,8 @@ def get_all_imports(path, encoding="utf-8", extra_ignore_dirs=None, follow_links
         "__pycache__",
         "env",
         "venv",
+        "test",
+        "tests",
         ".ipynb_checkpoints",
     ]
 


### PR DESCRIPTION
Avoid test/tests folder to ignore the file encoding issue, beasuse some package like IPython, joblib use the other encoding file for testing.