### PR TITLE
Add `--ignore-errors` to skip files with errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ Usage
         --debug               Print debug information
         --ignore <dirs>...    Ignore extra directories, each separated by a comma
         --no-follow-links     Do not follow symbolic links in the project
+        --ignore-errors       Ignore errors while scanning files
         --encoding <charset>  Use encoding parameter for file open
         --savepath <file>     Save the list of requirements in the given file
         --print               Output the list of requirements in the standard output

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -114,6 +114,13 @@ class TestPipreqs(unittest.TestCase):
         """
         self.assertRaises(SyntaxError, pipreqs.get_all_imports, self.project_invalid)
 
+    def test_ignore_errors(self):
+        """
+        Test that invalid python files do not raise an exception when ignore_errors is True.
+        """
+        imports = pipreqs.get_all_imports(self.project_invalid, ignore_errors=True)
+        self.assertEqual(len(imports), 0)
+
     def test_get_imports_info(self):
         """
         Test to see that the right number of packages were found on PyPI


### PR DESCRIPTION
## Overview

This PR introduces the `--ignore-errors` flag to pipreqs, allowing users to continue generating requirements.txt even if some files contain syntax errors. When this option is enabled, files with syntax errors will be skipped, and a warning will be logged instead of failing the entire process.

## Key Improvements Over [#287](https://github.com/bndr/pipreqs/pull/287)

I initially worked on this without being aware of PR #287, which proposed a similar change. After finishing my implementation, I became aware of #287 and reviewed it carefully. While I appreciate the original contribution, I believe this PR still provides additional value for the following reasons:

**Includes a Test Case**

This PR adds a test (`test_ignore_errors`) to ensure the new flag works correctly. The previous PR did not include a test, which could make it harder to verify correctness and prevent regressions in the future.

**Preserves Notebook Parsing Functionality**

Since #287 was opened, pipreqs has added support for reading Jupyter notebooks using read_file_content. However, it looks like there was an issue during conflict resolution in #287, causing the code to revert to reading files as plain text instead of using read_file_content.

I appreciate the work done in #287 and would be happy to collaborate to refine this feature. Let me know if any changes are needed! 😊