### PR TITLE
Migrate to `logger.warning`

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -147,7 +147,7 @@ def get_all_imports(path, encoding="utf-8", extra_ignore_dirs=None, follow_links
             except Exception as exc:
                 if ignore_errors:
                     traceback.print_exc()
-                    logging.warn("Failed on file: %s" % file_name)
+                    logging.warning("Failed on file: %s" % file_name)
                     continue
                 else:
                     logging.error("Failed on file: %s" % file_name)


### PR DESCRIPTION
## PR Summary
This small PR migrates from the deprecated `logger.warn` to the recommended `logger.warning` method. You can find the warnings in the [CI logs](https://github.com/bndr/pipreqs/actions/runs/15217991821/job/42807792448#step:5:34):
```python
 /home/runner/work/pipreqs/pipreqs/pipreqs/pipreqs.py:150: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
```