### PR TITLE
add file input error handling

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -516,6 +516,9 @@ def init(args):
         encoding = "utf-8"
     if input_path is None:
         input_path = os.path.abspath(os.curdir)
+    if not os.path.isdir(input_path):
+        logging.error(f"The path '{input_path}' is not a directory. Please provide a directory path.")
+        sys.exit(1)
 
     if extra_ignore_dirs:
         extra_ignore_dirs = extra_ignore_dirs.split(",")


### PR DESCRIPTION
This PR adds error handling for the case when the user provides a file instead of a directory.

# Example:

## Current version
`pipreqs project/main.py`:
```
Traceback (most recent call last):
  File "/usr/local/bin/pipreqs", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pipreqs/pipreqs.py", line 609, in main
    init(args)
  File "/usr/local/lib/python3.12/site-packages/pipreqs/pipreqs.py", line 599, in init
    generate_requirements_file(path, imports, symbol)
  File "/usr/local/lib/python3.12/site-packages/pipreqs/pipreqs.py", line 209, in generate_requirements_file
    with _open(path, "w") as out_file:
  File "/usr/local/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pipreqs/pipreqs.py", line 91, in _open
    file = open(filename, mode)
           ^^^^^^^^^^^^^^^^^^^^
NotADirectoryError: [Errno 20] Not a directory: 'project/main.py/requirements.txt'
```
## This fork
`pipreqs project/main.py`:
`ERROR: The path 'project/main.py' is not a directory. Please provide a directory path.
`

# Testing

This works properly in my tests.

### Question

Is this section in contributing guideline optional?:

> To run a subset of tests:
> 
> $ poetry run python -m unittest tests.test_pipreqs

Thanks!