### PR TITLE
Add `mesonpy > meson-python` mapping

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -777,6 +777,7 @@ marks:pytest_marks
 markupsafe:MarkupSafe
 mavnative:pymavlink
 memcache:python_memcached
+mesonpy:meson-python
 metacomm:AllPairs
 metaphone:Metafone
 metlog:metlog_py


### PR DESCRIPTION
Add the correct mapping to https://pypi.org/project/meson-python/

Refs https://github.com/astral-sh/uv/pull/15826