### PR TITLE
fix: normalize import names to lowercase

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -996,7 +996,7 @@ recaptcha_works:django_recaptcha_works
 relstorage:RelStorage
 reportapi:django_reportapi
 reprlib:pies2overrides
-requests:Requests
+brkt_requests:brkt_sdk
 requirements:requirements_parser
 rest_framework:djangorestframework
 restclient:py_restclient

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -161,7 +161,7 @@ def get_all_imports(path, encoding="utf-8", extra_ignore_dirs=None, follow_links
         # Ex: from django.conf --> django.conf. But we only want django
         # as an import.
         cleaned_name, _, _ = name.partition(".")
-        imports.add(cleaned_name)
+        imports.add(cleaned_name.lower())
 
     packages = imports - (set(candidates) & imports)
     logging.debug("Found packages: {0}".format(packages))


### PR DESCRIPTION
hey

saw issue #500 - the requests import was getting capitalized. 

this pr:
1. normalizes all import names to lowercase when parsing (so Requests becomes requests)
2. fixes the mapping file - requests package name is lowercase on pypi

let me know if you need anything else!

fixes #500