### PR TITLE
fix: avoid plain-dir import shadowing and refresh package mappings

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -106,6 +106,7 @@ agora:Agora_Fragment
 agora:Agora_Planner
 agora:Agora_Service_Provider
 agoraplex:agoraplex.themes.sphinx
+ahocorasick:pyahocorasick
 agsci:agsci.blognewsletter
 agx:agx.core
 agx:agx.dev
@@ -610,7 +611,7 @@ djkombu:django_kombu
 djorm_pgarray:djorm_ext_pgarray
 dns:dnspython
 docgen:ansible_docgenerator
-docker:docker_py
+docker:docker
 dogpile:dogpile.cache
 dogpile:dogpile.core
 dogshell:dogapi
@@ -793,8 +794,6 @@ mkrst_themes:2lazy2rest
 mockredis:mockredispy
 modargs:python_modargs
 model_utils:django_model_utils
-models:asposebarcode
-models:asposestorage
 moksha:moksha.common
 moksha:moksha.hub
 moksha:moksha.wsgi
@@ -809,7 +808,7 @@ mrbob:mr.bob
 msgpack:msgpack_python
 mutations:aino_mutations
 mws:amazon_mws
-mysql:mysql_connector_repackaged
+mysql:mysql-connector-python
 native_tags:django_native_tags
 ndg:ndg_httpsclient
 nereid:trytond_nereid
@@ -964,6 +963,7 @@ pymagic:libmagic
 pymycraawler:Amalwebcrawler
 pynma:AbakaffeNotifier
 pyphen:Pyphen
+pyro:pyro-ppl
 pyrimaa:AEI
 pysideuic:PySide
 pysqlite2:adhocracy_pysqlite
@@ -1052,8 +1052,7 @@ sphinx:Sphinx
 sphinx_pypi_upload:ATD_document
 sphinxcontrib:sphinxcontrib_programoutput
 sqlalchemy:SQLAlchemy
-src:atlas
-src:auto_mix_prep
+st_aggrid:streamlit-aggrid
 stats_toolkit:bw_stats_toolkit
 statsd:dogstatsd_python
 stdnum:python_stdnum

--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -126,8 +126,14 @@ def get_all_imports(path, encoding="utf-8", extra_ignore_dirs=None, follow_links
     for root, dirs, files in walk:
         dirs[:] = [d for d in dirs if d not in ignore_dirs]
 
-        candidates.append(os.path.basename(root))
         py_files = [file for file in files if file_ext_is_allowed(file, DEFAULT_EXTENSIONS)]
+        if root != path and py_files:
+            rel_root = os.path.relpath(root, path)
+            while rel_root not in (os.curdir, ""):
+                package_name = os.path.basename(rel_root)
+                if package_name:
+                    candidates.append(package_name)
+                rel_root = os.path.dirname(rel_root)
         candidates.extend([os.path.splitext(filename)[0] for filename in py_files])
 
         files = [fn for fn in files if file_ext_is_allowed(fn, extensions)]

--- a/tests/test_pipreqs.py
+++ b/tests/test_pipreqs.py
@@ -11,6 +11,7 @@ Tests for `pipreqs` module.
 from io import StringIO
 import logging
 from unittest.mock import patch, Mock
+import tempfile
 import unittest
 import os
 import requests
@@ -102,6 +103,34 @@ class TestPipreqs(unittest.TestCase):
         self.assertFalse("django" in imports)
         self.assertFalse("models" in imports)
 
+    def test_get_all_imports_does_not_hide_imports_behind_plain_dirs(self):
+        with tempfile.TemporaryDirectory() as project:
+            with open(os.path.join(project, "app.py"), "w") as f:
+                f.write("import numpy\nimport localpkg\n")
+            os.mkdir(os.path.join(project, "numpy"))
+            os.mkdir(os.path.join(project, "localpkg"))
+            with open(os.path.join(project, "localpkg", "__init__.py"), "w"):
+                pass
+
+            imports = pipreqs.get_all_imports(project)
+
+        self.assertIn("numpy", imports)
+        self.assertNotIn("localpkg", imports)
+
+    def test_get_all_imports_filters_pep420_namespace_packages(self):
+        with tempfile.TemporaryDirectory() as project:
+            with open(os.path.join(project, "app.py"), "w") as f:
+                f.write("import localns\nimport numpy\n")
+            os.makedirs(os.path.join(project, "localns"))
+            with open(os.path.join(project, "localns", "module.py"), "w") as f:
+                f.write("VALUE = 1\n")
+            os.mkdir(os.path.join(project, "numpy"))
+
+            imports = pipreqs.get_all_imports(project)
+
+        self.assertIn("numpy", imports)
+        self.assertNotIn("localns", imports)
+
     def test_deduplicate_dependencies(self):
         imports = pipreqs.get_all_imports(self.project_with_duplicated_deps)
         pkgs = pipreqs.get_pkg_names(imports)
@@ -141,6 +170,37 @@ class TestPipreqs(unittest.TestCase):
         actual_output = pipreqs.get_pkg_names(pkgs)
         expected_output = ["camel", "Caroline", "Japan", "jury"]
         self.assertEqual(actual_output, expected_output)
+
+    def test_get_pkg_names_maps_current_package_aliases(self):
+        pkgs = [
+            "ahocorasick",
+            "docker",
+            "models",
+            "mysql",
+            "pinecone",
+            "pyro",
+            "src",
+            "st_aggrid",
+        ]
+        actual_output = pipreqs.get_pkg_names(pkgs)
+        expected_output = sorted(
+            [
+                "docker",
+                "models",
+                "mysql-connector-python",
+                "pinecone",
+                "pyahocorasick",
+                "pyro-ppl",
+                "src",
+                "streamlit-aggrid",
+            ],
+            key=lambda s: s.lower(),
+        )
+        self.assertEqual(actual_output, expected_output)
+        self.assertNotIn("asposestorage", actual_output)
+        self.assertNotIn("auto_mix_prep", actual_output)
+        self.assertNotIn("docker_py", actual_output)
+        self.assertNotIn("mysql_connector_repackaged", actual_output)
 
     def test_get_use_local_only(self):
         """


### PR DESCRIPTION
## Summary

Two related fixes in one small PR:

1. **Import shadowing** — `get_all_imports` no longer treats every directory name under the scan root as a local package. Only paths that actually contain Python files (and their parent package segments) become candidates, so empty/data dirs no longer hide third-party imports. PEP 420-style dirs with real `.py` modules still count as local.
2. **Package mappings** — refresh a few stale alias rows for currently published names (`docker`, `mysql-connector-python`, `streamlit-aggrid`, `pyro-ppl`, `pyahocorasick`) and drop the overly generic `models` / `src` rows that can invent unrelated requirements for common local names. Leave `pinecone` as the current package name (no deprecated `pinecone-client` alias).

## Issues

Fixes #187
Fixes #233
Fixes #438
Related: #168, #177, #261, #281, #449, #329, #431

## Verification

```text
python3 -m unittest \
  tests.test_pipreqs.TestPipreqs.test_get_all_imports \
  tests.test_pipreqs.TestPipreqs.test_get_all_imports_does_not_hide_imports_behind_plain_dirs \
  tests.test_pipreqs.TestPipreqs.test_get_all_imports_filters_pep420_namespace_packages \
  tests.test_pipreqs.TestPipreqs.test_get_pkg_names \
  tests.test_pipreqs.TestPipreqs.test_get_pkg_names_maps_current_package_aliases
```

Also rechecked earlier by an external reviewer on Python 3.10 (focused tests + flake8 + whitespace).
