### PR TITLE
Add explicit UTF-8 encoding to internal file reads

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -166,7 +166,7 @@ def get_all_imports(path, encoding="utf-8", extra_ignore_dirs=None, follow_links
     packages = imports - (set(candidates) & imports)
     logging.debug("Found packages: {0}".format(packages))
 
-    with open(join("stdlib"), "r") as f:
+    with open(join("stdlib"), "r", encoding="utf-8") as f:
         data = {x.strip() for x in f}
 
     return list(packages - data)
@@ -333,7 +333,7 @@ def get_pkg_names(pkgs):
 
     """
     result = set()
-    with open(join("mapping"), "r") as f:
+    with open(join("mapping"), "r", encoding="utf-8") as f:
         data = dict(x.strip().split(":") for x in f)
     for pkg in pkgs:
         # Look up the mapped requirement. If a mapping isn't found,
@@ -380,7 +380,7 @@ def parse_requirements(file_):
     delim = ["<", ">", "=", "!", "~"]
 
     try:
-        f = open(file_, "r")
+        f = open(file_, "r", encoding="utf-8")
     except FileNotFoundError:
         print(f"File {file_} was not found. Please, fix it and run again.")
         sys.exit(1)


### PR DESCRIPTION
## Summary

Three `open()` calls in `pipreqs/pipreqs.py` read files without specifying an encoding, relying instead on the platform's default encoding (`locale.getpreferredencoding()`). On systems where that default isn't UTF-8 — for example GBK on Chinese Windows, or Latin-1 on some European locales — these reads fail with `UnicodeDecodeError`.

This affects:
- Fixes #241
- Fixes #271
- Fixes #469

## Changes

- `open(join("stdlib"), "r")` -> add `encoding="utf-8"` (reads pipreqs' own stdlib module list)
- `open(join("mapping"), "r")` -> add `encoding="utf-8"` (reads pipreqs' own import-to-package mapping file)
- `open(file_, "r")` in `parse_requirements` -> add `encoding="utf-8"`

The `stdlib` and `mapping` files are pipreqs' own bundled data files and are always UTF-8, so pinning the encoding explicitly is safe and makes behavior consistent across all platforms/locales instead of depending on the user's system default encoding.

## Test plan

- [x] Manually inspected all three call sites and confirmed `encoding="utf-8"` is a safe, no-behavior-change fix on UTF-8 systems
- [ ] Reproduce on a non-UTF-8-default system (e.g. Chinese Windows with GBK locale) and confirm `pipreqs` no longer raises `UnicodeDecodeError`