### PR TITLE
Add Flask extension package mappings

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -654,8 +654,15 @@ five:five.localsitemanager
 five:five.pt
 flasher:android_flasher
 flask:Flask
+flask_cors:Flask-Cors
 flask_frozen:Frozen_Flask
+flask_login:Flask-Login
+flask_mail:Flask-Mail
+flask_migrate:Flask-Migrate
 flask_redis:Flask_And_Redis
+flask_restful:Flask-RESTful
+flask_sqlalchemy:Flask-SQLAlchemy
+flask_wtf:Flask-WTF
 flaskext:Flask_Bcrypt
 flvscreen:vnc2flv
 followit:django_followit


### PR DESCRIPTION
Adds mappings for popular Flask extensions where the import name (underscore) differs from the PyPI name (hyphen/mixed case). Without these, pipreqs generates incorrect requirements with underscore names that pip cannot install.