### PR TITLE
Add security/monitoring package mappings (PyNaCl, sentry-sdk)

### DIFF
--- a/pipreqs/mapping
+++ b/pipreqs/mapping
@@ -810,6 +810,7 @@ msgpack:msgpack_python
 mutations:aino_mutations
 mws:amazon_mws
 mysql:mysql_connector_repackaged
+nacl:PyNaCl
 native_tags:django_native_tags
 ndg:ndg_httpsclient
 nereid:trytond_nereid
@@ -1026,6 +1027,7 @@ sdict:dict.sorted
 sdk_updater:android_sdk_updater
 sekizai:django_sekizai
 sendfile:pysendfile
+sentry_sdk:sentry-sdk
 serial:pyserial
 setuputils:astor
 shapefile:pyshp


### PR DESCRIPTION
Adds mappings for `nacl` (PyNaCl) and `sentry_sdk` (sentry-sdk) where import names differ from PyPI package names.