### PR TITLE
Fix encoding in _open() and clean() functions

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -89,7 +89,7 @@ def _open(filename=None, mode="r"):
         else:
             raise ValueError("Invalid mode for file: {}".format(mode))
     else:
-        file = open(filename, mode)
+        file = open(filename, mode, encoding="utf-8") if "b" not in mode else open(filename, mode)
 
     try:
         yield file
@@ -456,7 +456,7 @@ def clean(file_, imports):
     to_write = []
 
     try:
-        f = open(file_, "r+")
+        f = open(file_, "r+", encoding="utf-8")
     except OSError:
         logging.error("Failed on file: {}".format(file_))
         raise


### PR DESCRIPTION
Continuation of #542. Adds explicit UTF-8 encoding to two remaining open() calls:
- `_open()` context manager (line ~92): used when writing requirements.txt
- `clean()` function (line ~459): used when cleaning requirements.txt

Without these, pipreqs can produce garbled output or crash on systems with non-UTF-8 default encoding.

Fixes part of #241, #271, #469.