### PR TITLE
Handle SSL and connection errors gracefully in PyPI lookups

### DIFF
--- a/pipreqs/pipreqs.py
+++ b/pipreqs/pipreqs.py
@@ -244,7 +244,7 @@ def get_imports_info(imports, pypi_server="https://pypi.python.org/pypi/", proxy
                     data = json2package(response.content)
             elif response.status_code >= 300:
                 raise HTTPError(status_code=response.status_code, reason=response.reason)
-        except HTTPError:
+        except (HTTPError, requests.exceptions.SSLError, requests.exceptions.ConnectionError):
             logging.warning('Package "%s" does not exist or network problems', item)
             continue
         logging.warning(


### PR DESCRIPTION
When pipreqs queries PyPI for package info, SSL certificate errors or connection timeouts crash the entire run instead of being handled gracefully. This is particularly common on corporate networks with SSL inspection or in environments with outdated certificate bundles.

This change catches SSLError and ConnectionError alongside HTTPError, logging a warning and continuing with the next package — matching the existing graceful-degradation behavior.

Fixes #400.