### PR TITLE
ci: Add Windows and macOS to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,15 @@ on:
 
 jobs:
     run_tests:
-        runs-on: ubuntu-24.04
+        runs-on: ${{ matrix.os }}
         strategy:
             fail-fast: false
             matrix:
-                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
+                os: [ubuntu-24.04, windows-latest, macos-latest]
+                python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+                exclude:
+                    - os: macos-latest
+                      python-version: '3.9'
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
The existing CI only runs on Ubuntu, but several open bugs (#241, #271, #469) are platform-specific encoding issues that only manifest on Windows (GBK default encoding) and European Linux/macOS (Latin-1 default).

Adding Windows and macOS to the test matrix ensures platform-specific regressions are caught. This is particularly important given the recent encoding fixes in #542 and #548.

Changes:
- Added `windows-latest` and `macos-latest` to the OS matrix
- Excluded Python 3.9 on macOS (unavailable on ARM runners)
- Removed pypy to keep CI time manageable